### PR TITLE
Spawn wave location feature

### DIFF
--- a/SpawnControl/Config.cs
+++ b/SpawnControl/Config.cs
@@ -62,8 +62,8 @@ namespace SpawnWaveControl
                 { RoleType.Scp93953, "SCP_939"},
                 { RoleType.Scp93989, "SCP_939"},
 
-                {RoleType.ClassD, "TUT Spawn"},
-                {RoleType.Scientist, "TUT Spawn" }
+                {RoleType.ClassD, "SP_CDP"},
+                {RoleType.Scientist, "SP_RSC" }
 
             };
 

--- a/SpawnControl/Config.cs
+++ b/SpawnControl/Config.cs
@@ -38,6 +38,46 @@ namespace SpawnWaveControl
                 { "Mtf_Config", false }
             };
 
+        [Description("Gives spawn wave location control based on what you set. Very graular control.")]
+        public Dictionary<RoleType, string> RoleSpawnLocations { get; set; } =
+            new Dictionary<RoleType, string>
+            {
+                { RoleType.FacilityGuard, "SP_GUARD"},
+                { RoleType.NtfPrivate, "SP_MTF"},
+                { RoleType.NtfSergeant, "SP_MTF"},
+                { RoleType.NtfCaptain, "SP_MTF"},
+                { RoleType.NtfSpecialist, "SP_MTF"},
+
+                { RoleType.ChaosConscript,"SP_CI"},
+                { RoleType.ChaosMarauder,"SP_CI"},
+                { RoleType.ChaosRepressor,"SP_CI"},
+                { RoleType.ChaosRifleman,"SP_CI"},
+
+                { RoleType.Scp049, "SP_049"},
+                { RoleType.Scp0492, null},
+                { RoleType.Scp079, "SP_079"},
+                { RoleType.Scp096, "SCP_096"},
+                { RoleType.Scp106, "SP_106"},
+                { RoleType.Scp173, "SP_173"},
+                { RoleType.Scp93953, "SCP_939"},
+                { RoleType.Scp93989, "SCP_939"}
+
+            };
+
+        [Description("Gives spawn wave location control based on what you set. Would NOT recommend using this for MTF/SCP")]
+        public Dictionary<Team, string> UniqueGroupsSpawnLocations { get; set; } =
+            new Dictionary<Team, string>
+            {
+                { Team.MTF, "SP_MTF" },
+                { Team.CHI, "SP_CI" },
+                { Team.RSC, "SP_RSC"},
+                { Team.CDP, "SP_CDP" },
+                { Team.TUT, "TUT Spawn" }
+            };
+
+        [Description("Flag to enable control of the spawn locations of specific groups")]
+        public bool spawn_location_control { get; set; } = false;
+
         [Description("probability flag (Changes from % X will spawn to % chance to spawn X type).")]
         public bool probability_flag { get; set; } = false;
 

--- a/SpawnControl/Config.cs
+++ b/SpawnControl/Config.cs
@@ -60,7 +60,10 @@ namespace SpawnWaveControl
                 { RoleType.Scp106, "SP_106"},
                 { RoleType.Scp173, "SP_173"},
                 { RoleType.Scp93953, "SCP_939"},
-                { RoleType.Scp93989, "SCP_939"}
+                { RoleType.Scp93989, "SCP_939"},
+
+                {RoleType.ClassD, "TUT Spawn"},
+                {RoleType.Scientist, "TUT Spawn" }
 
             };
 

--- a/SpawnControl/Handlers/PlayerSpawnControl.cs
+++ b/SpawnControl/Handlers/PlayerSpawnControl.cs
@@ -1,0 +1,6 @@
+﻿namespace SpawnWaveControl.Handlers
+{
+    internal class PlayerSpawnControl
+    {
+    }
+}

--- a/SpawnControl/Handlers/RespawnTeamControl.cs
+++ b/SpawnControl/Handlers/RespawnTeamControl.cs
@@ -1,0 +1,7 @@
+﻿namespace SpawnWaveControl.Handlers
+{
+    internal class RespawnTeamControl
+    {
+
+    }
+}

--- a/SpawnControl/Patches/MtfSpawnPatcher.cs
+++ b/SpawnControl/Patches/MtfSpawnPatcher.cs
@@ -7,6 +7,12 @@ using System.Collections.Generic;
 namespace SpawnWaveControl.Patches
 {
 
+    /*
+     * [HarmonyPatch(typeof(PatchTargetClass), 
+         nameof(PatchTargetClass.TargetMethodName), 
+         new[] {typeof(float), typeof(int)} ]
+    */
+
     [HarmonyPatch(typeof(NineTailedFoxSpawnHandler))]
     [HarmonyPatch(nameof(NineTailedFoxSpawnHandler.GenerateQueue), MethodType.Normal)]
     public class MtfSpawnPatcher

--- a/SpawnControl/Patches/SpawnPointManagerPatcher.cs
+++ b/SpawnControl/Patches/SpawnPointManagerPatcher.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using Exiled.API.Features;
+using HarmonyLib;
 using SpawnWaveControl.Utilities;
 using System;
 using System.Collections.Generic;
@@ -21,17 +22,17 @@ namespace SpawnWaveControl.Patches
         [HarmonyPrefix]
         public static bool SpawnPointPatcher()
         {
-            SpawnWaveControl.early_config.ProgramLevel.TryGetValue("spawn_location_control", out bool is_enabled);
-
+            bool is_enabled = SpawnWaveControl.early_config.spawn_location_control;
+            Log.Info($"Are we even calling this? What is is_enabled {is_enabled}");
             if (!is_enabled)
             {
                 //Runs the normal code execution
-                LoggerTool.log_msg_static("We were not enabled. Letting original method run");
+                LoggerTool.log_msg_static("We were not enabled for SpawnPointPatcher. Letting original method run");
                 return true;
             }
-
+            Log.Info("Hello");
             Dictionary<RoleType, string> group_spawn_locations = SpawnWaveControl.early_config.RoleSpawnLocations;
-
+            LoggerTool.log_msg_static("We were enabled and are now going to start touching things");
             global::SpawnpointManager.Positions.Clear();
             foreach (RoleType available_roles in Enum.GetValues(typeof(global::RoleType)))
             {
@@ -51,14 +52,18 @@ namespace SpawnWaveControl.Patches
                 return null;
             }
 
+            LoggerTool.log_msg_static($"We are going to check if {unique_group_spawn_location == null} is null");
             if (unique_group_spawn_location == null)
             {
+                LoggerTool.log_msg_static($"What the hell is our classID {classID}");
                 if (!group_spawn_location.TryGetValue(classID, out string unique_group_data))
                 {
+                    LoggerTool.log_msg_static($"What the hell is our unique data if false {string.Join(Environment.NewLine, group_spawn_location)}");
                     return GameObject.FindGameObjectsWithTag("SP_RSC");
                 }
                 else
                 {
+                    LoggerTool.log_msg_static($"What the hell is our classID unique group {unique_group_data}");
                     return GameObject.FindGameObjectsWithTag(unique_group_data);
                 }
 

--- a/SpawnControl/Patches/SpawnPointManagerPatcher.cs
+++ b/SpawnControl/Patches/SpawnPointManagerPatcher.cs
@@ -21,7 +21,7 @@ namespace SpawnWaveControl.Patches
         [HarmonyPrefix]
         public static bool SpawnPointPatcher()
         {
-            SpawnWaveControl.early_config.ProgramLevel.TryGetValue("Mtf_Config", out bool is_enabled);
+            SpawnWaveControl.early_config.ProgramLevel.TryGetValue("spawn_location_control", out bool is_enabled);
 
             if (!is_enabled)
             {
@@ -55,7 +55,7 @@ namespace SpawnWaveControl.Patches
             {
                 if (!group_spawn_location.TryGetValue(classID, out string unique_group_data))
                 {
-                    return null;
+                    return GameObject.FindGameObjectsWithTag("SP_RSC");
                 }
                 else
                 {

--- a/SpawnControl/Patches/SpawnPointManagerPatcher.cs
+++ b/SpawnControl/Patches/SpawnPointManagerPatcher.cs
@@ -1,0 +1,170 @@
+﻿using HarmonyLib;
+using SpawnWaveControl.Utilities;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SpawnWaveControl.Patches
+{
+    /*
+ * [HarmonyPatch(typeof(PatchTargetClass), 
+     nameof(PatchTargetClass.TargetMethodName), 
+     new[] {typeof(float), typeof(int)} ]
+*/
+
+    //https://harmony.pardeike.net/articles/basics.html patch specific functions
+    [HarmonyPatch(typeof(SpawnpointManager))]
+    [HarmonyPatch(nameof(SpawnpointManager.FillSpawnPoints), MethodType.Normal)]
+    public class SpawnPointManagerPatcher
+    {
+
+        [HarmonyPrefix]
+        public static bool SpawnPointPatcher()
+        {
+            SpawnWaveControl.early_config.ProgramLevel.TryGetValue("Mtf_Config", out bool is_enabled);
+
+            if (!is_enabled)
+            {
+                //Runs the normal code execution
+                LoggerTool.log_msg_static("We were not enabled. Letting original method run");
+                return true;
+            }
+
+            Dictionary<RoleType, string> group_spawn_locations = SpawnWaveControl.early_config.RoleSpawnLocations;
+
+            global::SpawnpointManager.Positions.Clear();
+            foreach (RoleType available_roles in Enum.GetValues(typeof(global::RoleType)))
+            {
+                if (available_roles != global::RoleType.None || available_roles != global::RoleType.Spectator)
+                {
+                    global::SpawnpointManager.Positions.Add(available_roles, GetArrayOfPositionsOverride(available_roles, group_spawn_locations));
+                }
+            }
+            return false;
+        }
+        public static GameObject[] GetArrayOfPositionsOverride(global::RoleType classID,
+            Dictionary<RoleType, string> group_spawn_location, Dictionary<Team, string> unique_group_spawn_location = null)
+        {
+
+            if (classID == global::RoleType.Scp0492)
+            {
+                return null;
+            }
+
+            if (unique_group_spawn_location == null)
+            {
+                if (!group_spawn_location.TryGetValue(classID, out string unique_group_data))
+                {
+                    return null;
+                }
+                else
+                {
+                    return GameObject.FindGameObjectsWithTag(unique_group_data);
+                }
+
+            }
+            else
+            {
+                global::Role role = GameObject.Find("Host").GetComponent<global::CharacterClassManager>().Classes.SafeGet(classID);
+                switch (role.team)
+                {
+                    case global::Team.SCP:
+                        if (!unique_group_spawn_location.TryGetValue(Team.SCP, out string unique_team_data))
+                        {
+                            return default_scp_logic(classID);
+                        }
+                        return generate_new_scp_logic(classID, unique_team_data);
+                    case global::Team.MTF:
+                        if (!unique_group_spawn_location.TryGetValue(Team.MTF, out string mtf_unique_team_data))
+                        {
+                            return GameObject.FindGameObjectsWithTag((classID == global::RoleType.FacilityGuard) ? "SP_GUARD" : "SP_MTF");
+                        }
+                        return GameObject.FindGameObjectsWithTag(mtf_unique_team_data);
+                    case global::Team.CHI:
+                        if (!unique_group_spawn_location.TryGetValue(Team.CHI, out string chi_unique_team_data))
+                        {
+                            return GameObject.FindGameObjectsWithTag("SP_CI");
+                        }
+                        return GameObject.FindGameObjectsWithTag(chi_unique_team_data);
+                    case global::Team.RSC:
+                        if (!unique_group_spawn_location.TryGetValue(Team.SCP, out string rsc_unique_team_data))
+                        {
+                            return GameObject.FindGameObjectsWithTag("SP_RSC");
+                        }
+                        return GameObject.FindGameObjectsWithTag(rsc_unique_team_data);
+                    case global::Team.CDP:
+                        if (!unique_group_spawn_location.TryGetValue(Team.SCP, out string cdp_unique_team_data))
+                        {
+                            return GameObject.FindGameObjectsWithTag("SP_CDP");
+                        }
+                        return GameObject.FindGameObjectsWithTag(cdp_unique_team_data);
+                    case global::Team.TUT:
+                        if (!unique_group_spawn_location.TryGetValue(Team.SCP, out string tut_unique_team_data))
+                        {
+                            return new GameObject[]
+                            {
+                                GameObject.Find("TUT Spawn")
+                            };
+                        }
+                        return new GameObject[]
+                        {
+                            GameObject.Find(tut_unique_team_data)
+                        };
+                }
+            }
+            return null;
+        }
+
+        private static GameObject[] generate_new_scp_logic(RoleType classID, string unique_team_data)
+        {
+            switch (classID)
+            {
+                case global::RoleType.Scp106:
+                    return GameObject.FindGameObjectsWithTag(unique_team_data);
+                case global::RoleType.NtfSpecialist:
+                case global::RoleType.Scientist:
+                case global::RoleType.ChaosConscript:
+                    break;
+                case global::RoleType.Scp049:
+                    return GameObject.FindGameObjectsWithTag(unique_team_data);
+                case global::RoleType.Scp079:
+                    return GameObject.FindGameObjectsWithTag(unique_team_data);
+                case global::RoleType.Scp096:
+                    return GameObject.FindGameObjectsWithTag(unique_team_data);
+                default:
+                    if (classID - global::RoleType.Scp93953 <= 1)
+                    {
+                        return GameObject.FindGameObjectsWithTag(unique_team_data);
+                    }
+                    break;
+            }
+            return GameObject.FindGameObjectsWithTag(unique_team_data);
+        }
+
+        private static GameObject[] default_scp_logic(RoleType classID)
+        {
+            switch (classID)
+            {
+                case global::RoleType.Scp106:
+                    return GameObject.FindGameObjectsWithTag("SP_106");
+                case global::RoleType.NtfSpecialist:
+                case global::RoleType.Scientist:
+                case global::RoleType.ChaosConscript:
+                    break;
+                case global::RoleType.Scp049:
+                    return GameObject.FindGameObjectsWithTag("SP_049");
+                case global::RoleType.Scp079:
+                    return GameObject.FindGameObjectsWithTag("SP_079");
+                case global::RoleType.Scp096:
+                    return GameObject.FindGameObjectsWithTag("SCP_096");
+                default:
+                    if (classID - global::RoleType.Scp93953 <= 1)
+                    {
+                        return GameObject.FindGameObjectsWithTag("SCP_939");
+                    }
+                    break;
+            }
+            return GameObject.FindGameObjectsWithTag("SP_173");
+        }
+    }
+}

--- a/SpawnControl/Patches/SpawnPointManagerPatcher.cs
+++ b/SpawnControl/Patches/SpawnPointManagerPatcher.cs
@@ -55,11 +55,11 @@ namespace SpawnWaveControl.Patches
             LoggerTool.log_msg_static($"We are going to check if {unique_group_spawn_location == null} is null");
             if (unique_group_spawn_location == null)
             {
-                LoggerTool.log_msg_static($"What the hell is our classID {classID}");
+                LoggerTool.log_msg_static($"What is our classID {classID}");
                 if (!group_spawn_location.TryGetValue(classID, out string unique_group_data))
                 {
-                    LoggerTool.log_msg_static($"What the hell is our unique data if false {string.Join(Environment.NewLine, group_spawn_location)}");
-                    return GameObject.FindGameObjectsWithTag("SP_RSC");
+
+                    return default_nw_logic(classID);
                 }
                 else
                 {
@@ -76,40 +76,37 @@ namespace SpawnWaveControl.Patches
                     case global::Team.SCP:
                         if (!unique_group_spawn_location.TryGetValue(Team.SCP, out string unique_team_data))
                         {
-                            return default_scp_logic(classID);
+                            return default_nw_logic(classID);
                         }
                         return generate_new_scp_logic(classID, unique_team_data);
                     case global::Team.MTF:
                         if (!unique_group_spawn_location.TryGetValue(Team.MTF, out string mtf_unique_team_data))
                         {
-                            return GameObject.FindGameObjectsWithTag((classID == global::RoleType.FacilityGuard) ? "SP_GUARD" : "SP_MTF");
+                            return default_nw_logic(classID);
                         }
                         return GameObject.FindGameObjectsWithTag(mtf_unique_team_data);
                     case global::Team.CHI:
                         if (!unique_group_spawn_location.TryGetValue(Team.CHI, out string chi_unique_team_data))
                         {
-                            return GameObject.FindGameObjectsWithTag("SP_CI");
+                            return default_nw_logic(classID);
                         }
                         return GameObject.FindGameObjectsWithTag(chi_unique_team_data);
                     case global::Team.RSC:
                         if (!unique_group_spawn_location.TryGetValue(Team.SCP, out string rsc_unique_team_data))
                         {
-                            return GameObject.FindGameObjectsWithTag("SP_RSC");
+                            return default_nw_logic(classID);
                         }
                         return GameObject.FindGameObjectsWithTag(rsc_unique_team_data);
                     case global::Team.CDP:
                         if (!unique_group_spawn_location.TryGetValue(Team.SCP, out string cdp_unique_team_data))
                         {
-                            return GameObject.FindGameObjectsWithTag("SP_CDP");
+                            return default_nw_logic(classID);
                         }
                         return GameObject.FindGameObjectsWithTag(cdp_unique_team_data);
                     case global::Team.TUT:
                         if (!unique_group_spawn_location.TryGetValue(Team.SCP, out string tut_unique_team_data))
                         {
-                            return new GameObject[]
-                            {
-                                GameObject.Find("TUT Spawn")
-                            };
+                            return default_nw_logic(classID);
                         }
                         return new GameObject[]
                         {
@@ -146,30 +143,53 @@ namespace SpawnWaveControl.Patches
             return GameObject.FindGameObjectsWithTag(unique_team_data);
         }
 
-        private static GameObject[] default_scp_logic(RoleType classID)
+        private static GameObject[] default_nw_logic(RoleType classID)
         {
-            switch (classID)
+            global::Role role = GameObject.Find("Host").GetComponent<global::CharacterClassManager>().Classes.SafeGet(classID);
+            if (classID == global::RoleType.Scp0492)
             {
-                case global::RoleType.Scp106:
-                    return GameObject.FindGameObjectsWithTag("SP_106");
-                case global::RoleType.NtfSpecialist:
-                case global::RoleType.Scientist:
-                case global::RoleType.ChaosConscript:
-                    break;
-                case global::RoleType.Scp049:
-                    return GameObject.FindGameObjectsWithTag("SP_049");
-                case global::RoleType.Scp079:
-                    return GameObject.FindGameObjectsWithTag("SP_079");
-                case global::RoleType.Scp096:
-                    return GameObject.FindGameObjectsWithTag("SCP_096");
-                default:
-                    if (classID - global::RoleType.Scp93953 <= 1)
-                    {
-                        return GameObject.FindGameObjectsWithTag("SCP_939");
-                    }
-                    break;
+                return null;
             }
-            return GameObject.FindGameObjectsWithTag("SP_173");
+            switch (role.team)
+            {
+                case global::Team.SCP:
+                    switch (classID)
+                    {
+                        case global::RoleType.Scp106:
+                            return GameObject.FindGameObjectsWithTag("SP_106");
+                        case global::RoleType.NtfSpecialist:
+                        case global::RoleType.Scientist:
+                        case global::RoleType.ChaosConscript:
+                            break;
+                        case global::RoleType.Scp049:
+                            return GameObject.FindGameObjectsWithTag("SP_049");
+                        case global::RoleType.Scp079:
+                            return GameObject.FindGameObjectsWithTag("SP_079");
+                        case global::RoleType.Scp096:
+                            return GameObject.FindGameObjectsWithTag("SCP_096");
+                        default:
+                            if (classID - global::RoleType.Scp93953 <= 1)
+                            {
+                                return GameObject.FindGameObjectsWithTag("SCP_939");
+                            }
+                            break;
+                    }
+                    return GameObject.FindGameObjectsWithTag("SP_173");
+                case global::Team.MTF:
+                    return GameObject.FindGameObjectsWithTag((classID == global::RoleType.FacilityGuard) ? "SP_GUARD" : "SP_MTF");
+                case global::Team.CHI:
+                    return GameObject.FindGameObjectsWithTag("SP_CI");
+                case global::Team.RSC:
+                    return GameObject.FindGameObjectsWithTag("SP_RSC");
+                case global::Team.CDP:
+                    return GameObject.FindGameObjectsWithTag("SP_CDP");
+                case global::Team.TUT:
+                    return new GameObject[]
+                    {
+                GameObject.Find("TUT Spawn")
+                    };
+            }
+            return null;
         }
     }
 }

--- a/SpawnControl/Properties/AssemblyInfo.cs
+++ b/SpawnControl/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
@@ -32,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.1")]
-[assembly: AssemblyFileVersion("1.0.0.1")]
+[assembly: AssemblyVersion("1.0.0.2")]
+[assembly: AssemblyFileVersion("1.0.0.2")]

--- a/SpawnControl/Properties/AssemblyInfo.cs
+++ b/SpawnControl/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("SpawnControl")]
-[assembly: AssemblyDescription("Ability to control spawnrates of MTF, CHAOS.")]
+[assembly: AssemblyDescription("Ability to control spawn of MTF, CHAOS and location.")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("SpawnControl")]
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.2")]
-[assembly: AssemblyFileVersion("1.0.0.2")]
+[assembly: AssemblyVersion("1.0.0.3")]
+[assembly: AssemblyFileVersion("1.0.0.3")]

--- a/SpawnControl/SpawnWaveControl.cs
+++ b/SpawnControl/SpawnWaveControl.cs
@@ -2,7 +2,6 @@
 using Exiled.API.Features;
 using HarmonyLib;
 using System;
-
 namespace SpawnWaveControl
 {
     public class SpawnWaveControl : Plugin<Config>
@@ -58,6 +57,7 @@ namespace SpawnWaveControl
                 return;
             }
             early_config = Config;
+
             Log.Info("SpawnControl has been loaded");
 
         }

--- a/SpawnControl/SpawnWaveControl.csproj
+++ b/SpawnControl/SpawnWaveControl.csproj
@@ -69,6 +69,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.TextRenderingModule">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\UnityEngine.TextRenderingModule.dll</HintPath>
     </Reference>
@@ -119,6 +127,7 @@
     <Compile Include="Config.cs" />
     <Compile Include="Patches\ChaosSpawnPatcher.cs" />
     <Compile Include="Patches\MtfSpawnPatcher.cs" />
+    <Compile Include="Patches\SpawnPointManagerPatcher.cs" />
     <Compile Include="SpawnWaveControl.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utilities\generalizedSpawner.cs" />


### PR DESCRIPTION
Alright, new feature.

Includes change to allow users to specific what groups will spawn where.

You can be very granular in control for specific roles, or in general for the entire team.

I would NOT recommend doing the "Team" settings, especially for MTF and SCP as NW's approach made too many entities share the same team without considering modification, and they were hard-coded. 